### PR TITLE
feat: add contexts support

### DIFF
--- a/tests/mocks/add_context_response
+++ b/tests/mocks/add_context_response
@@ -1,0 +1,5 @@
+{
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "name": "testcontext",
+  "created_at": "2015-09-21T17:29:21.042Z"
+}

--- a/tests/mocks/delete_context_response
+++ b/tests/mocks/delete_context_response
@@ -1,0 +1,3 @@
+{
+    "message": "Context deleted."
+}

--- a/tests/mocks/get_context_response
+++ b/tests/mocks/get_context_response
@@ -1,0 +1,5 @@
+{
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "name": "testcontext",
+    "created_at": "2015-09-21T17:29:21.042Z"
+}

--- a/tests/mocks/get_contexts_response
+++ b/tests/mocks/get_contexts_response
@@ -1,0 +1,16 @@
+{
+  "next_page_token" : null,
+  "items" : [ {
+    "name" : "context1",
+    "id" : "a2683f02-d716-4b1e-bb61-d8a5cf5308f1",
+    "created_at" : "2021-10-22T22:56:25.658Z"
+  }, {
+    "name" : "context2",
+    "id" : "0912cb18-1b03-4cbf-bb91-bfdb51fa58a9",
+    "created_at" : "2021-10-29T01:35:37.088Z"
+  }, {
+    "name" : "foobar",
+    "id" : "c2e606d6-4555-4fad-8183-655224411f21",
+    "created_at" : "2021-10-19T03:40:58.198Z"
+  } ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -243,6 +243,117 @@ class TestCircleciApi(unittest.TestCase):
 
         self.assertEqual(resp["message"], "ok")
 
+    def test_get_contexts(self):
+        self.get_mock("get_contexts_response")
+        resp = js(self.c.get_contexts("user"))
+
+        self.c._request.assert_called_once_with(
+            "GET",
+            "context",
+            params={
+                "owner-type": "organization",
+                "owner-slug": "github/user",
+            },
+            api_version="v2",
+            paginate=False,
+            limit=None,
+        )
+        self.assertEqual(resp["items"][0]["name"], "context1")
+        self.assertEqual(resp["items"][2]["name"], "foobar")
+        self.assertEqual(resp["items"][0]["id"], "a2683f02-d716-4b1e-bb61-d8a5cf5308f1")
+
+    def test_get_contexts_owner_id(self):
+        self.get_mock("get_contexts_response")
+        resp = js(self.c.get_contexts(owner_id="c65b68ef-e73b-4bf2-be9a-7a322a9df150"))
+
+        self.c._request.assert_called_once_with(
+            "GET",
+            "context",
+            params={
+                "owner-type": "organization",
+                "owner-id": "c65b68ef-e73b-4bf2-be9a-7a322a9df150",
+            },
+            api_version="v2",
+            paginate=False,
+            limit=None,
+        )
+        self.assertEqual(resp["items"][0]["name"], "context1")
+
+    def test_get_contexts_owner_type(self):
+        self.get_mock("get_contexts_response")
+        resp = js(self.c.get_contexts("user", owner_type="account"))
+
+        self.c._request.assert_called_once_with(
+            "GET",
+            "context",
+            params={
+                "owner-type": "account",
+                "owner-slug": "github/user",
+            },
+            api_version="v2",
+            paginate=False,
+            limit=None,
+        )
+        self.assertEqual(resp["items"][0]["name"], "context1")
+
+    def test_add_context(self):
+        self.get_mock("add_context_response")
+        resp = js(self.c.add_context("testcontext", "user"))
+
+        self.c._request.assert_called_once_with(
+            "POST",
+            "context",
+            data={
+                "name": "testcontext",
+                "owner": {
+                    "type": "organization",
+                    "slug": "github/user",
+                }
+            },
+            api_version="v2",
+        )
+        self.assertEqual(resp["name"], "testcontext")
+
+    def test_add_context_organization(self):
+        self.get_mock("add_context_response")
+        resp = js(self.c.add_context("testcontext", "user", owner_type="account"))
+
+        self.c._request.assert_called_once_with(
+            "POST",
+            "context",
+            data={
+                "name": "testcontext",
+                "owner": {
+                    "type": "account",
+                    "slug": "github/user",
+                }
+            },
+            api_version="v2",
+        )
+        self.assertEqual(resp["name"], "testcontext")
+
+    def test_get_context(self):
+        self.get_mock("get_context_response")
+        resp = js(self.c.get_context("497f6eca-6276-4993-bfeb-53cbbbba6f08"))
+
+        self.c._request.assert_called_once_with(
+            "GET",
+            "context/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            api_version="v2",
+        )
+        self.assertEqual(resp["name"], "testcontext")
+
+    def test_delete_context(self):
+        self.get_mock("delete_context_response")
+        resp = js(self.c.delete_context("497f6eca-6276-4993-bfeb-53cbbbba6f08"))
+
+        self.c._request.assert_called_once_with(
+            "DELETE",
+            "context/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            api_version="v2",
+        )
+        self.assertEqual(resp["message"], "Context deleted.")
+
     def test_get_latest_artifact(self):
         self.get_mock("get_latest_artifacts_response")
         resp = js(self.c.get_latest_artifact("user", "circleci-sandbox"))


### PR DESCRIPTION
Fixes #14
- Add support for adding, deleting, and getting contexts via the v2 API
- Add some new helper methods for dealing with cases where the slug gets
  passed in as a parameter vs. via the API endpoint.

https://circleci.com/docs/api/v2/#operation/createContext
https://circleci.com/docs/api/v2/#operation/getContext
https://circleci.com/docs/api/v2/#operation/listContexts
https://circleci.com/docs/api/v2/#operation/deleteContext

Assuming these look good, and this project is being maintained, I can work on adding support for adding / updating / removing env vars within contexts as a followup.