### PR TITLE
fix contexts and add context environment variable support

### DIFF
--- a/pycircleci/api.py
+++ b/pycircleci/api.py
@@ -775,7 +775,7 @@ class Api:
         elif owner_id:
             params["owner-id"] = owner_id
 
-        resp = self._request_get_depaginate(GET, "context", params=params, api_version=API_VER_V2, paginate=paginate, limit=limit)
+        resp = self._request_get_depaginate("context", params=params, api_version=API_VER_V2, paginate=paginate, limit=limit)
         return resp
 
     def add_context(self, name, username=None, owner_id=None, owner_type=ORGANIZATION, vcs_type=GITHUB):

--- a/pycircleci/api.py
+++ b/pycircleci/api.py
@@ -826,6 +826,51 @@ class Api:
         resp = self._request(DELETE, endpoint, api_version=API_VER_V2)
         return resp
 
+    def get_context_envvars(self, context_id, paginate=False, limit=None):
+        """Get environment variables for a context
+
+        :param context_id: ID of context to retrieve environment variables from
+        :param paginate: If True, repeatedly requests more items from the endpoint until the limit has been reached (or until all results have been fetched). Defaults to False..
+        :param limit: Maximum number of items to return. By default returns all the results from multiple calls to the endpoint, or all the results from a single call to the endpoint, depending on the value for ``paginate``.
+
+        Endpoint:
+            GET ``/v2/context/:context_id/environment-variable``
+        """
+        endpoint = "context/{0}/environment-variable".format(context_id)
+
+        resp = self._request_get_depaginate(endpoint, api_version=API_VER_V2, paginate=paginate, limit=limit)
+        return resp
+
+    def add_context_envvar(self, context_id, name, value):
+        """Add or update an environment variable to a context.
+
+        :param context_id: ID of the context to add environment variable to.
+        :param name: Name of the environment variable.
+        :param value: Value of the environment variable.
+
+        Endpoint:
+            PUT: ``/context/:context-id/environment-variable/:name``
+        """
+        data = {"value": value}
+        endpoint = "context/{0}/environment-variable/{1}".format(context_id, name)
+
+        resp = self._request(PUT, endpoint, api_version=API_VER_V2, data=data)
+        return resp
+
+    def delete_context_envvar(self, context_id, name):
+        """Delete an environment variable from a context.
+
+        :param context_id: ID of the context to delete environment variable from.
+        :param name: Name of the environment variable.
+
+        Endpoint:
+            DELETE: ``/context/:context-id/environment-variable/:name``
+        """
+        endpoint = "context/{0}/environment-variable/{1}".format(context_id, name)
+
+        resp = self._request(DELETE, endpoint, api_version=API_VER_V2)
+        return resp
+
     def get_project_settings(self, username, project, vcs_type=GITHUB):
         """Get project advanced settings.
 

--- a/tests/mocks/add_context_envvar_response
+++ b/tests/mocks/add_context_envvar_response
@@ -1,0 +1,5 @@
+{
+   "context_id" : "f31d7249-b7b1-4729-b3a4-ec0ba07b4686",
+   "created_at" : "2021-11-06T00:25:40.393Z",
+   "variable" : "FOOBAR"
+}

--- a/tests/mocks/delete_context_envvar_response
+++ b/tests/mocks/delete_context_envvar_response
@@ -1,0 +1,3 @@
+{
+   "message" : "Environment variable deleted."
+}

--- a/tests/mocks/get_context_envvars_response
+++ b/tests/mocks/get_context_envvars_response
@@ -1,0 +1,17 @@
+[
+   {
+      "context_id" : "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "created_at" : "2021-11-06T00:25:40.393Z",
+      "variable" : "foobar"
+   },
+   {
+      "context_id" : "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "created_at" : "2021-11-06T00:42:03.148Z",
+      "variable" : "FOOBAR"
+   },
+   {
+      "context_id" : "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "created_at" : "2021-11-06T00:42:11.094Z",
+      "variable" : "FOOBAR2"
+   }
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,46 @@ class TestCircleciApi(unittest.TestCase):
         )
         self.assertEqual(resp["message"], "Context deleted.")
 
+    def test_get_context_envvars(self):
+        self.get_mock("get_context_envvars_response")
+        resp = js(self.c.get_context_envvars("a5b6416b-369e-44a9-8d47-8970325d4134"))
+
+        self.c._request_get_depaginate.assert_called_once_with(
+            "context/a5b6416b-369e-44a9-8d47-8970325d4134/environment-variable",
+            api_version="v2",
+            paginate=False,
+            limit=None,
+        )
+        self.assertEqual(resp[1]["variable"], "FOOBAR")
+        self.assertEqual(resp[2]["variable"], "FOOBAR2")
+
+    def test_add_context_envvar(self):
+        self.get_mock("add_context_envvar_response")
+        resp = js(self.c.add_context_envvar(
+            "f31d7249-b7b1-4729-b3a4-ec0ba07b4686", "FOOBAR", "BAZ"
+        ))
+
+        self.c._request.assert_called_once_with(
+            "PUT",
+            "context/f31d7249-b7b1-4729-b3a4-ec0ba07b4686/environment-variable/FOOBAR",
+            api_version="v2",
+            data={"value": "BAZ"},
+        )
+        self.assertEqual(resp["variable"], "FOOBAR")
+
+    def test_delete_context_envvar(self):
+        self.get_mock("delete_context_envvar_response")
+        resp = js(self.c.delete_context_envvar(
+            "f31d7249-b7b1-4729-b3a4-ec0ba07b4686", "FOOBAR"
+        ))
+
+        self.c._request.assert_called_once_with(
+            "DELETE",
+            "context/f31d7249-b7b1-4729-b3a4-ec0ba07b4686/environment-variable/FOOBAR",
+            api_version="v2",
+        )
+        self.assertEqual(resp["message"], "Environment variable deleted.")
+
     def test_get_latest_artifact(self):
         self.get_mock("get_latest_artifacts_response")
         resp = js(self.c.get_latest_artifact("user", "circleci-sandbox"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,9 @@ class TestCircleciApi(unittest.TestCase):
         """Get a mock response from file"""
         filename = "tests/mocks/{0}".format(filename)
         with open(filename, "r") as f:
-            self.c._request = self.c._request_get_depaginate = MagicMock(return_value=f.read())
+            mock_value = f.read()
+            self.c._request = MagicMock(return_value=mock_value)
+            self.c._request_get_depaginate = MagicMock(return_value=mock_value)
 
     def test_bad_verb(self):
         with self.assertRaises(CircleciError) as e:
@@ -247,8 +249,7 @@ class TestCircleciApi(unittest.TestCase):
         self.get_mock("get_contexts_response")
         resp = js(self.c.get_contexts("user"))
 
-        self.c._request.assert_called_once_with(
-            "GET",
+        self.c._request_get_depaginate.assert_called_once_with(
             "context",
             params={
                 "owner-type": "organization",
@@ -266,8 +267,7 @@ class TestCircleciApi(unittest.TestCase):
         self.get_mock("get_contexts_response")
         resp = js(self.c.get_contexts(owner_id="c65b68ef-e73b-4bf2-be9a-7a322a9df150"))
 
-        self.c._request.assert_called_once_with(
-            "GET",
+        self.c._request_get_depaginate.assert_called_once_with(
             "context",
             params={
                 "owner-type": "organization",
@@ -283,8 +283,7 @@ class TestCircleciApi(unittest.TestCase):
         self.get_mock("get_contexts_response")
         resp = js(self.c.get_contexts("user", owner_type="account"))
 
-        self.c._request.assert_called_once_with(
-            "GET",
+        self.c._request_get_depaginate.assert_called_once_with(
             "context",
             params={
                 "owner-type": "account",


### PR DESCRIPTION
Two separate commits that should be merged atomically.
 
1) Resolve error with `get_contexts()`:
The call for the get_contexts() method didn't get switched to `_request_get_depaginate()` the second time this was rebased. While this was fixed (in #19), the verb is no longer sent to that method, so I believe this (adjusted) is still necessary.

2) Add support for the remaining endpoints related to contexts

- get_context_envvars()
- add_context_envvar()
- delete_context_envvar()
    
https://circleci.com/docs/api/v2/#operation/listEnvironmentVariablesFromContext
https://circleci.com/docs/api/v2/#operation/addEnvironmentVariableToContext
https://circleci.com/docs/api/v2/#operation/deleteEnvironmentVariableFromContext