### PR TITLE
Update deprecated Retry class option

### DIFF
--- a/pycircleci/api.py
+++ b/pycircleci/api.py
@@ -1230,7 +1230,7 @@ class Api:
             total=retries,
             backoff_factor=backoff_factor,
             status_forcelist=status_forcelist,
-            method_whitelist=False,
+            allowed_methods=False,
             raise_on_redirect=False,
             raise_on_status=False,
             respect_retry_after_header=False,


### PR DESCRIPTION
Received the following warning from pytest.  This is consistent with the [urllib3 docs page](https://urllib3.readthedocs.io/en/1.26.8/reference/urllib3.util.html).  This is a small change to update the option.

```
====================================== warnings summary =======================================

DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed 
in v2.0. Use 'allowed_methods' instead
    retry = Retry(

===================================== 1 warning in 0.32s =========
```