### PR TITLE
Update flake8 config for v6

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,9 @@
 [flake8]
 extend-ignore =
-    E501 # line length limit
-    E203 # see https://github.com/PyCQA/pycodestyle/issues/373
+    # line length limit
+    E501,
+    # see https://github.com/PyCQA/pycodestyle/issues/373
+    E203
 exclude =
     .git,
     .mypy_cache,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-flake8
-flake8-quotes
+flake8 ~= 6.0
+flake8-quotes ~=3.0
 pytest
 requests
 requests-toolbelt


### PR DESCRIPTION
`flake8` >= v6 throws an error with the current config. Move the comments above the items and add commas after each item, and pin the versions of `flake8` and `flake8-quotes` in `requirements-dev.txt`.

https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30