### PR TITLE
Add build system info to comply with PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Since version 22.3 pip has issued a warning 
```
 DEPRECATION: flake8-quotes is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
```
Adding a `pyproject.toml` with `build-system` info explicitly indicates how the package is built and allows pip >=23 to install the project locally.