### PR TITLE
Add flaky test endpoint

### DIFF
--- a/pycircleci/api.py
+++ b/pycircleci/api.py
@@ -1015,6 +1015,21 @@ class Api:
         resp = self._request(GET, endpoint, params=params, api_version=API_VER_V2)
         return resp
 
+    def get_flaky_tests(self, username, project, vcs_type=GITHUB):
+        """Get a list of flaky tests for a given project.
+
+        :param username: Org or user name.
+        :param project: Repo name.
+        :param vcs_type: VCS type (github, bitbucket). Defaults to ``github``.
+
+        Endpoint:
+            GET ``/insights/:vcs-type/:username/:project/flaky-tests``
+        """
+        slug = self.project_slug(username, project, vcs_type)
+        endpoint = f"insights/{slug}/flaky-tests"
+        resp = self._request(GET, endpoint, api_version=API_VER_V2)
+        return resp
+
     def get_project_workflows_metrics(self, username, project, params=None, vcs_type=GITHUB, paginate=False, limit=None):
         """Get summary metrics for a project's workflows.
 

--- a/tests/mocks/get_flaky_tests_response.json
+++ b/tests/mocks/get_flaky_tests_response.json
@@ -1,0 +1,33 @@
+{
+  "flaky_tests": [
+    {
+      "workflow_created_at": "2023-04-24T16:48:19Z",
+      "classname": "yea",
+      "job_number": 547148,
+      "times_flaked": 10,
+      "source": "",
+      "pipeline_number": 21702,
+      "file": "",
+      "workflow_name": "main",
+      "job_name": "func-win-base-py39",
+      "workflow_id": "0cc5a532-ca97-48e4-9fab-da01bffaae11",
+      "time_wasted": 0,
+      "test_name": "0.debug.8"
+    },
+    {
+      "workflow_created_at": "2023-04-26T21:55:20Z",
+      "classname": "tests.pytest_tests.unit_tests.test_lib.test_filesystem",
+      "job_number": 554986,
+      "times_flaked": 5,
+      "source": "",
+      "pipeline_number": 22837,
+      "file": "",
+      "workflow_name": "main",
+      "job_name": "unit-win-py39",
+      "workflow_id": "51fa7e3a-0e7f-425b-b970-c9fe346e9876",
+      "time_wasted": 0,
+      "test_name": "test_safe_copy_with_file_changes"
+    }
+  ],
+  "total_flaky_tests": 2
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -480,6 +480,14 @@ def test_get_project_branches(cci):
     assert "master" in resp["branches"]
 
 
+def test_get_flaky_tests(cci):
+    get_mock(cci, "get_flaky_tests_response.json")
+    resp = cci.get_flaky_tests("foo", "bar")
+    assert resp["total_flaky_tests"] == 2
+    assert len(resp["flaky_tests"]) == 2
+    assert resp["flaky_tests"][0]["times_flaked"] == 10
+
+
 def test_get_project_workflows_metrics_depaginated(cci):
     get_mock(cci, "get_project_workflows_metrics_response.json")
     resp = cci.get_project_workflows_metrics("foo", "bar")


### PR DESCRIPTION
Add method to retrieve flaky test info from the Insights endpoint (https://circleci.com/docs/api/v2/index.html#operation/getFlakyTests)